### PR TITLE
openvpn: fix hotplug 01-user to get up/down scripts parameters that are otherwise lost

### DIFF
--- a/net/openvpn/files/etc/hotplug.d/openvpn/01-user
+++ b/net/openvpn/files/etc/hotplug.d/openvpn/01-user
@@ -12,7 +12,7 @@
 # Wrap user defined scripts on up/down events
 case "$ACTION" in
 	up|down)
-		if get_openvpn_option "$config" command "$ACTION"; then
+		if command=$(uci get "openvpn.${INSTANCE}.${ACTION}"); then
 			shift
 			exec /bin/sh -c "$command $*"
 		fi


### PR DESCRIPTION
Maintainer: me / @nbd168
Compile tested: (arch: lantiq, BT Home Hub 5, OpenWrt 21.02)
Run tested: (lantiq, BT Home Hub 5, OpenWrt 21.02, tests done)

Description: openvpn hotplug script 01-user tries to get up/down scripts parameters from the translated ovpn configuration file, but these were stripped and are no longer present.
This patch amends 01-user to get up/down scripts parameters from the uci openvpn instance configuration instead

Signed-off-by: Mauro Mozzarelli <ezplanet@users.noreply.github.com>